### PR TITLE
Skills and Language migration

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,3 +1,3 @@
 class Language < ApplicationRecord
-  belongs_to :skill
+  belongs_to :volunteer
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,0 +1,3 @@
+class Language < ApplicationRecord
+  belongs_to :skill
+end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,4 +1,3 @@
 class Skill < ApplicationRecord
   belongs_to :volunteer
-  has_many :languages
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,4 @@
+class Skill < ApplicationRecord
+  belongs_to :volunteer
+  has_many :languages
+end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,3 +1,4 @@
 class Volunteer < User
   has_many :skills
+  has_many :languages
 end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,3 +1,3 @@
 class Volunteer < User
-
+  has_many :skills
 end

--- a/db/migrate/20200411162619_create_skills.rb
+++ b/db/migrate/20200411162619_create_skills.rb
@@ -1,0 +1,12 @@
+class CreateSkills < ActiveRecord::Migration[5.2]
+  def change
+    create_table :skills do |t|
+      t.string :name
+      t.string :level
+      t.integer :years_of_experience
+      t.references :volunteer, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200411170004_create_languages.rb
+++ b/db/migrate/20200411170004_create_languages.rb
@@ -1,0 +1,11 @@
+class CreateLanguages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :languages do |t|
+      t.string :name
+      t.string :level
+      t.references :skill, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200411170942_create_languages.rb
+++ b/db/migrate/20200411170942_create_languages.rb
@@ -3,7 +3,7 @@ class CreateLanguages < ActiveRecord::Migration[5.2]
     create_table :languages do |t|
       t.string :name
       t.string :level
-      t.references :skill, foreign_key: true
+      t.references :volunteer, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_11_145352) do
-
+ActiveRecord::Schema.define(version: 2020_04_11_170004) do
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
     t.index ["jti"], name: "index_jwt_blacklist_on_jti"
+
+  create_table "languages", force: :cascade do |t|
+    t.string "name"
+    t.string "level"
+    t.integer "skill_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["skill_id"], name: "index_languages_on_skill_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -23,6 +30,16 @@ ActiveRecord::Schema.define(version: 2020_04_11_145352) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+  create_table "skills", force: :cascade do |t|
+    t.string "name"
+    t.string "level"
+    t.integer "years_of_experience"
+    t.integer "volunteer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["volunteer_id"], name: "index_skills_on_volunteer_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_11_170004) do
+ActiveRecord::Schema.define(version: 2020_04_11_170942) do
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
     t.index ["jti"], name: "index_jwt_blacklist_on_jti"
@@ -18,10 +18,10 @@ ActiveRecord::Schema.define(version: 2020_04_11_170004) do
   create_table "languages", force: :cascade do |t|
     t.string "name"
     t.string "level"
-    t.integer "skill_id"
+    t.integer "volunteer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["skill_id"], name: "index_languages_on_skill_id"
+    t.index ["volunteer_id"], name: "index_languages_on_volunteer_id"
   end
 
   create_table "messages", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,12 +7,20 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 10.times do |i|
-  Volunteer.create(
+  volunteer = Volunteer.create!(
     email: "test#{i}@email.com",
     encrypted_password: "password#{i}",
+    password: "password#{i}",
     first_name: "first_name_#{i}",
     last_name: "last_name_#{i}",
     bio: "I am volunteer ##{i} and I love connect-educate :D",
-    birth_date: "#{i+1}/12/1994" 
+    birth_date: "#{i+1}/12/1994"
   )
+  volunteer.save
+  first_skill = volunteer.skills.create!(name: "cool skill #{i}", level: 'beginner', years_of_experience: 1)
+  second_skill = volunteer.skills.create!(name: "another cool skill #{i}", level: 'intermediate', years_of_experience: 3)
+  first_skill.save
+  second_skill.save
+  language = first_skill.languages.create!(name: "language #{i}", level: 'native')
+  language.save
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,10 +17,8 @@
     birth_date: "#{i+1}/12/1994"
   )
   volunteer.save
-  first_skill = volunteer.skills.create!(name: "cool skill #{i}", level: 'beginner', years_of_experience: 1)
-  second_skill = volunteer.skills.create!(name: "another cool skill #{i}", level: 'intermediate', years_of_experience: 3)
-  first_skill.save
-  second_skill.save
-  language = first_skill.languages.create!(name: "language #{i}", level: 'native')
-  language.save
+  volunteer.skills.create!(name: "cool skill #{i}", level: 'beginner', years_of_experience: 1)
+  volunteer.skills.create!(name: "another cool skill #{i}", level: 'intermediate', years_of_experience: 3)
+  volunteer.languages.create!(name: "language #{i}", level: 'native')
+  volunteer.languages.create!(name: "language #{i}", level: 'native')
 end


### PR DESCRIPTION
- Add model and migration for Skills table (has many to one relationship with Volunteer)
- Add model and migration for Languages table (has many to one relationship with Volunteer)

I've separated language from skill (rather than having language just as a skill type) so that language can be re-used more easily, and it will be easier for the FE to determine which volunteers speak what languages, and at what level

For now the language `name` and skill `name` are of type `string` rather than some form of enum, with the idea being that the FE will display a dropdown of pre-defined language types and skill types. These field types could be updated on the BE to constrain to these lists, but we will need to figure out a way to prevent this becoming two sources of truth that have the potential to diverge without notice.
The same principle also applies for the `level` fields of the `language` and `skill` tables.