### PR TITLE
Change name fields from string to enum type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'devise'
 gem 'devise-jwt'
+gem 'language_list', '~> 1.2', '>= 1.2.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
+    language_list (1.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -168,6 +169,7 @@ DEPENDENCIES
   byebug
   devise
   devise-jwt
+  language_list (~> 1.2, >= 1.2.1)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/app/controllers/api/v1/languages_controller.rb
+++ b/app/controllers/api/v1/languages_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class LanguagesController < ApplicationController
+      def index
+          languages = LanguageList::COMMON_LANGUAGES
+          render json: languages
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/languages_controller.rb
+++ b/app/controllers/api/v1/languages_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     class LanguagesController < ApplicationController
       def index
-          languages = LanguageList::COMMON_LANGUAGES
-          render json: languages
+        languages = LanguageList::COMMON_LANGUAGES
+        render json: languages
       end
     end
   end

--- a/app/controllers/api/v1/skills_controller.rb
+++ b/app/controllers/api/v1/skills_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class SkillsController < ApplicationController
+      def index
+        skills = Skill::SKILLS
+        render json: skills
+      end
+    end
+  end
+end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,3 +1,6 @@
 class Language < ApplicationRecord
   belongs_to :volunteer
+
+  languages = LanguageList::COMMON_LANGUAGES
+  enum name: Hash[languages.map.with_index { |l, i| [ l.name, i+1 ] }] 
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,5 +1,7 @@
 class Skill < ApplicationRecord
+  SKILLS = ['Maths', 'English', 'Physics', 'Chemistry', 'Biology', 'Geography', 'History', 'Programming']
+
   belongs_to :volunteer
 
-  enum name: { maths: 0, english: 1, physics: 2, chemistry: 3, biology: 4, geography: 5, history: 6, computer_science: 7 }
+  enum name: Hash[SKILLS.map.with_index { |l, i| [ l, i+1 ] }] 
 end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,3 +1,5 @@
 class Skill < ApplicationRecord
   belongs_to :volunteer
+
+  enum name: { maths: 0, english: 1, physics: 2, chemistry: 3, biology: 4, geography: 5, history: 6, computer_science: 7 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :posts
       resources :messages
       resources :volunteers
+      resources :languages
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :messages
       resources :volunteers
       resources :languages
+      resources :skills
     end
   end
 

--- a/db/migrate/20200412074814_change_name_to_be_enum_in_languages.rb
+++ b/db/migrate/20200412074814_change_name_to_be_enum_in_languages.rb
@@ -1,0 +1,5 @@
+class ChangeNameToBeEnumInLanguages < ActiveRecord::Migration[5.2]
+  def change
+    change_column :languages, :name, :integer
+  end
+end

--- a/db/migrate/20200412080040_change_name_to_be_enum_in_skills.rb
+++ b/db/migrate/20200412080040_change_name_to_be_enum_in_skills.rb
@@ -1,0 +1,5 @@
+class ChangeNameToBeEnumInSkills < ActiveRecord::Migration[5.2]
+  def change
+    change_column :skills, :name, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_11_170942) do
+ActiveRecord::Schema.define(version: 2020_04_12_074814) do
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_04_11_170942) do
   end
 
   create_table "languages", force: :cascade do |t|
-    t.string "name"
+    t.integer "name"
     t.string "level"
     t.integer "volunteer_id"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_12_074814) do
+ActiveRecord::Schema.define(version: 2020_04_12_080040) do
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 2020_04_12_074814) do
   end
 
   create_table "skills", force: :cascade do |t|
-    t.string "name"
+    t.integer "name"
     t.string "level"
     t.integer "years_of_experience"
     t.integer "volunteer_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,8 +19,8 @@
   volunteer.save
   volunteer.skills.create!(name: "cool skill #{i}", level: 'beginner', years_of_experience: 1)
   volunteer.skills.create!(name: "another cool skill #{i}", level: 'intermediate', years_of_experience: 3)
-  volunteer.languages.create!(name: "language #{i}", level: 'native')
-  volunteer.languages.create!(name: "language #{i}", level: 'native')
+  volunteer.languages.create!(name: 2, level: 'native')
+  volunteer.languages.create!(name: 3, level: 'fluent')
 end
 
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,8 +17,8 @@
     birth_date: "#{i+1}/12/1994"
   )
   volunteer.save
-  volunteer.skills.create!(name: "cool skill #{i}", level: 'beginner', years_of_experience: 1)
-  volunteer.skills.create!(name: "another cool skill #{i}", level: 'intermediate', years_of_experience: 3)
+  volunteer.skills.create!(name: 1, level: 'beginner', years_of_experience: 1)
+  volunteer.skills.create!(name: 8, level: 'intermediate', years_of_experience: 3)
   volunteer.languages.create!(name: 2, level: 'native')
   volunteer.languages.create!(name: 3, level: 'fluent')
 end


### PR DESCRIPTION
- Change name field from string to enum type in `languages` table - I've done this using hash notation rather than array, as with the array notation there's a vulnerability whereby the mapping between declared values and integers kept in the database is based on order in the array (whereas with the hash we can control the mapping between value and integer), meaning values cannot be safely added and removed from the enum array.
- Change name field from string to enum type in `skills` table - also done using hash notation (see above point for reason)
- Add a get endpoint to get the list of common languages (143 in total) - this is to be the source of truth for the languages that are to be displayed to the volunteer on the FE when they're creating their account
- Add a get endpoint to get the list of skills - this is to be the source of truth for the skills that are to be displayed to the volunteer on the FE when they're creating their account (this list is not complete - waiting on more skills, but it can be easily updated)