### PR TITLE
Message thread and assign volunteers

### DIFF
--- a/app/controllers/api/v1/assign_volunteer_controller.rb
+++ b/app/controllers/api/v1/assign_volunteer_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class AssignVolunteerController < ApplicationController
+      before_action :authenticate_user!
       def update
         params.require(:id)
         params.require(:volunteer)

--- a/app/controllers/api/v1/assign_volunteer_controller.rb
+++ b/app/controllers/api/v1/assign_volunteer_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class AssignVolunteerController < ApplicationController
+      def update
+        task_id = params[:id]
+        volunteer_id = params[:volunteer]
+        task = Task.find_by(id: task_id)
+        if task
+          task.update(volunteer_id: volunteer_id)
+        else
+          render json: { error: 'Task not found.' }, status: 404
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/assign_volunteer_controller.rb
+++ b/app/controllers/api/v1/assign_volunteer_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     class AssignVolunteerController < ApplicationController
       def update
+        params.require(:id)
+        params.require(:volunteer)
         task_id = params[:id]
         volunteer_id = params[:volunteer]
         task = Task.find_by(id: task_id)

--- a/app/controllers/api/v1/message_thread_controller.rb
+++ b/app/controllers/api/v1/message_thread_controller.rb
@@ -5,7 +5,7 @@ module Api
         task_id = params[:id]
         messages = Message.where(task_id: task_id)
         if !messages.empty?
-          render json: message
+          render json: messages
         else
           render json: { error: 'Messages not found.' }, status: 404
         end

--- a/app/controllers/api/v1/message_thread_controller.rb
+++ b/app/controllers/api/v1/message_thread_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class MessageThreadController < ApplicationController
+      before_action :authenticate_user!
       def show
         task_id = params[:id]
         messages = Message.where(task_id: task_id)

--- a/app/controllers/api/v1/message_thread_controller.rb
+++ b/app/controllers/api/v1/message_thread_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class MessageThreadController < ApplicationController
+      def show
+        task_id = params[:id]
+        messages = Message.where(task_id: task_id)
+        if !messages.empty?
+          render json: message
+        else
+          render json: { error: 'Messages not found.' }, status: 404
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -32,7 +32,7 @@ module Api
             # can we send attachments? 
 
             def message_params
-                params.require(:content, :user_id)
+                params.require(:content, :user_id, :task_id)
             end
             
         end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -32,7 +32,10 @@ module Api
             # can we send attachments? 
 
             def message_params
-                params.require(:content, :user_id, :task_id)
+                params.require(:content)
+                params.require(:user_id)
+                params.require(:task_id)
+                params.permit(:content, :user_id, :task_id)
             end
             
         end

--- a/app/controllers/api/v1/unassign_volunteer_controller.rb
+++ b/app/controllers/api/v1/unassign_volunteer_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class UnassignVolunteerController < ApplicationController
+      before_action :authenticate_user!
       def update
         params.require(:id)
         params.require(:volunteer)

--- a/app/controllers/api/v1/unassign_volunteer_controller.rb
+++ b/app/controllers/api/v1/unassign_volunteer_controller.rb
@@ -6,7 +6,7 @@ module Api
         volunteer_id = params[:volunteer]
         task = Task.where(id: task_id).where(volunteer_id: volunteer_id)
         if !task.empty
-          task.update(volunteer_id: volunteer_id)
+          task.update(volunteer_id: null)
         else
           render json: { error: 'Task not found.' }, status: 404
         end

--- a/app/controllers/api/v1/unassign_volunteer_controller.rb
+++ b/app/controllers/api/v1/unassign_volunteer_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class UnAssignVolunteerController < ApplicationController
+      def update
+        task_id = params[:id]
+        volunteer_id = params[:volunteer]
+        task = Task.where(id: task_id).where(volunteer_id: volunteer_id)
+        if !task.empty
+          task.update(volunteer_id: volunteer_id)
+        else
+          render json: { error: 'Task not found.' }, status: 404
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/unassign_volunteer_controller.rb
+++ b/app/controllers/api/v1/unassign_volunteer_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     class UnassignVolunteerController < ApplicationController
       def update
+        params.require(:id)
+        params.require(:volunteer)
         task_id = params[:id]
         volunteer_id = params[:volunteer]
         task = Task.where(id: task_id).where(volunteer_id: volunteer_id)

--- a/app/controllers/api/v1/unassign_volunteer_controller.rb
+++ b/app/controllers/api/v1/unassign_volunteer_controller.rb
@@ -1,12 +1,12 @@
 module Api
   module V1
-    class UnAssignVolunteerController < ApplicationController
+    class UnassignVolunteerController < ApplicationController
       def update
         task_id = params[:id]
         volunteer_id = params[:volunteer]
         task = Task.where(id: task_id).where(volunteer_id: volunteer_id)
-        if !task.empty
-          task.update(volunteer_id: null)
+        if !task.empty?
+          task.update(volunteer_id: nil)
         else
           render json: { error: 'Task not found.' }, status: 404
         end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,6 @@
 class Message < ApplicationRecord
   belongs_to :user
+  belongs_to :task
 
   validates :content, :user_id, presence: true
   validates :content, length: { minimum: 1 } 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :parent
-  # belongs_to :volunteer
+  belongs_to :volunteer, optional: true
 
   validates :content, :parent_id, :skill, presence: true
   validates :content, length: { minimum: 5 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
       resources :languages
       resources :skills
       resources :assign_volunteer, path: 'assign-volunteer'
+      resources :unassign_volunteer, path: 'unassign-volunteer'
+      resources :message_thread, path: 'message-thread'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :volunteers
       resources :languages
       resources :skills
+      resources :assign_volunteer, path: 'assign-volunteer'
     end
   end
 

--- a/db/migrate/20200412141848_add_task_fk_to_message.rb
+++ b/db/migrate/20200412141848_add_task_fk_to_message.rb
@@ -1,0 +1,5 @@
+class AddTaskFkToMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :messages, :task, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-
 ActiveRecord::Schema.define(version: 2020_04_12_171212) do
-=======
-ActiveRecord::Schema.define(version: 2020_04_12_141848) do
->>>>>>> Add auth to assign volunteer and message thread endpoints
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+
 ActiveRecord::Schema.define(version: 2020_04_12_171212) do
 
   create_table "jwt_blacklist", force: :cascade do |t|
@@ -31,6 +32,8 @@ ActiveRecord::Schema.define(version: 2020_04_12_171212) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "task_id"
+    t.index ["task_id"], name: "index_messages_on_task_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,10 +40,10 @@ ActiveRecord::Schema.define(version: 2020_04_12_171212) do
     t.integer "name"
     t.string "level"
     t.integer "years_of_experience"
-    t.integer "user_id"
+    t.integer "volunteer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_skills_on_user_id"
+    t.index ["volunteer_id"], name: "index_skills_on_volunteer_id"
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 
 ActiveRecord::Schema.define(version: 2020_04_12_171212) do
+=======
+ActiveRecord::Schema.define(version: 2020_04_12_141848) do
+>>>>>>> Add auth to assign volunteer and message thread endpoints
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
@@ -41,10 +45,10 @@ ActiveRecord::Schema.define(version: 2020_04_12_171212) do
     t.integer "name"
     t.string "level"
     t.integer "years_of_experience"
-    t.integer "volunteer_id"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["volunteer_id"], name: "index_skills_on_volunteer_id"
+    t.index ["user_id"], name: "index_skills_on_user_id"
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,9 +33,9 @@ parent = Parent.create!(
   birth_date: "23/01/1994"
 )
 parent.save
-task = Task.create!(content: 'cool content', skill_id: 1, parent_id: parent.id)
+task = Task.create!(content: 'cool content', skill: 'really cool skill', parent_id: parent.id)
 task.save
-task2 = Task.create!(content: 'cool content', skill_id: 1, parent_id: parent.id)
+task2 = Task.create!(content: 'cool content', skill: 'another cool skill', parent_id: parent.id)
 task2.save
 Message.create!(content: 'im a message', user_id: parent.id, task_id: task.id)
 Message.create!(content: 'im another message', user_id: parent.id, task_id: task2.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,5 +23,22 @@
   volunteer.languages.create!(name: 3, level: 'fluent')
 end
 
+parent = Parent.create!(
+  email: "test55@email.com",
+  encrypted_password: "password#55",
+  password: "password#55",
+  first_name: "first_name_55",
+  last_name: "last_name_55",
+  bio: "I am volunteer #55 and I love connect-educate :D",
+  birth_date: "23/01/1994"
+)
+parent.save
+task = Task.create!(content: 'cool content', skill_id: 1, parent_id: parent.id)
+task.save
+task2 = Task.create!(content: 'cool content', skill_id: 1, parent_id: parent.id)
+task2.save
+Message.create!(content: 'im a message', user_id: parent.id, task_id: task.id)
+Message.create!(content: 'im another message', user_id: parent.id, task_id: task2.id)
+
 
 # We should create an Anonymous user so that Posts can have user_id as a reference, in case people do want to be logged in and post with their name appearing. As this would be required, then when Anon is selected a fake user should be appointed to this post?


### PR DESCRIPTION
- Add `put` endpoint to assign volunteer to a task
- Add `put` endpoint to unassign volunteer to a task
- Add `get` endpoint to get a message thread for a task
   - Add `task` foreign key to `message`
   - Set `task_id` when message is created
   - Add `belongs_to :task` to message model

**Some tidy ups / fixes:**
- Fix check of message params in `create` message controller method
- Make `belong_to :volunteer` `optional` on task model, otherwise an error is thrown when creating a task, because the task doesn't have a `volunteer_id` set on initial creation, it will only have one when and if a volunteer is assigned to the task
- Add some message and task seeded data for testing purposes

**Testing**
Just to confirm, these new endpoints (+ get volunteers + get volunteer + get skills + get languages + post message + get tasks) have been successfully tested against my local db using curl
