### PR TITLE
Add endpoint to get list of message threads for parent

### DIFF
--- a/app/controllers/api/v1/message_threads_for_parent_controller.rb
+++ b/app/controllers/api/v1/message_threads_for_parent_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    class MessageThreadsForParentController < ApplicationController
+      # before_action :authenticate_user!
+      def show
+        user_id = params[:id]
+        tasks = Task.where(parent_id: user_id)
+        messages = tasks.map do |t|
+          messages_for_task = Message.where(task_id: t.id)
+          messages_for_task.last if !messages_for_task.empty?
+        end
+        messages = messages.compact
+        if !messages.empty?
+          render json: messages
+        else
+          render json: { error: 'Messages not found.' }, status: 404
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :assign_volunteer, path: 'assign-volunteer'
       resources :unassign_volunteer, path: 'unassign-volunteer'
       resources :message_thread, path: 'message-thread'
+      resources :message_threads_for_parent, path: 'message-threads'
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,12 +33,15 @@ parent = Parent.create!(
   birth_date: "23/01/1994"
 )
 parent.save
-task = Task.create!(content: 'cool content', skill: 'really cool skill', parent_id: parent.id)
+task = Task.create!(content: 'I would like help with maths', skill: 'maths', parent_id: parent.id)
 task.save
-task2 = Task.create!(content: 'cool content', skill: 'another cool skill', parent_id: parent.id)
+task2 = Task.create!(content: 'I would like help with physics', skill: 'science', parent_id: parent.id)
 task2.save
-Message.create!(content: 'im a message', user_id: parent.id, task_id: task.id)
-Message.create!(content: 'im another message', user_id: parent.id, task_id: task2.id)
+task3 = Task.create!(content: 'I would like help with chemistry', skill: 'science', parent_id: parent.id)
+task3.save
+Message.create!(content: 'im task 1 message', user_id: parent.id, task_id: task.id)
+Message.create!(content: 'im another task 1 message', user_id: parent.id, task_id: task.id)
+Message.create!(content: 'im a task 2 message', user_id: parent.id, task_id: task2.id)
 
 
 # We should create an Anonymous user so that Posts can have user_id as a reference, in case people do want to be logged in and post with their name appearing. As this would be required, then when Anon is selected a fake user should be appointed to this post?


### PR DESCRIPTION
- Adds an endpoint to get a list of message threads for parents (element per thread, each element is the latest message in the thread) and can be used for a 'my messages' page, and gives enough info (`task_id`) to make a get request for the full message thread.

For the purpose of volunteers viewing message threads, the task id is already in the response from the get task request