### PR TITLE
Configure postgres db + sort migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby '2.6.1'
 gem 'rails', '~> 5.2.3'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pg (1.2.3)
     puma (3.12.4)
     rack (2.2.2)
     rack-cors (1.1.1)
@@ -178,6 +179,7 @@ DEPENDENCIES
   jwt
   language_list (~> 1.2, >= 1.2.1)
   listen (>= 3.0.5, < 3.2)
+  pg
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.3)

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,22 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: connect_educate_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: connect_educate_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: connect_educate_production

--- a/db/migrate/20200411162619_create_skills.rb
+++ b/db/migrate/20200411162619_create_skills.rb
@@ -4,7 +4,7 @@ class CreateSkills < ActiveRecord::Migration[5.2]
       t.string :name
       t.string :level
       t.integer :years_of_experience
-      t.references :user, foreign_key: true
+      t.references :volunteer, foreign_key: { to_table: 'users' }
 
       t.timestamps
     end

--- a/db/migrate/20200411170942_create_languages.rb
+++ b/db/migrate/20200411170942_create_languages.rb
@@ -3,7 +3,7 @@ class CreateLanguages < ActiveRecord::Migration[5.2]
     create_table :languages do |t|
       t.string :name
       t.string :level
-      t.references :volunteer, foreign_key: true
+      t.references :volunteer, foreign_key: { to_table: 'users' }
 
       t.timestamps
     end

--- a/db/migrate/20200412074814_change_name_to_be_enum_in_languages.rb
+++ b/db/migrate/20200412074814_change_name_to_be_enum_in_languages.rb
@@ -1,5 +1,5 @@
 class ChangeNameToBeEnumInLanguages < ActiveRecord::Migration[5.2]
   def change
-    change_column :languages, :name, :integer
+    change_column :languages, :name, 'integer USING CAST("name" AS integer)'
   end
 end

--- a/db/migrate/20200412080040_change_name_to_be_enum_in_skills.rb
+++ b/db/migrate/20200412080040_change_name_to_be_enum_in_skills.rb
@@ -1,5 +1,5 @@
 class ChangeNameToBeEnumInSkills < ActiveRecord::Migration[5.2]
   def change
-    change_column :skills, :name, :integer
+    change_column :skills, :name, 'integer USING CAST("name" AS integer)'
   end
 end

--- a/db/migrate/20200412120954_drop_posts_languages_table.rb
+++ b/db/migrate/20200412120954_drop_posts_languages_table.rb
@@ -1,9 +1,0 @@
-class DropPostsLanguagesTable < ActiveRecord::Migration[5.2]
-  def up
-    drop_table :posts_languages
-  end
-
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
-end

--- a/db/migrate/20200412121000_drop_posts_skills_table.rb
+++ b/db/migrate/20200412121000_drop_posts_skills_table.rb
@@ -1,9 +1,0 @@
-class DropPostsSkillsTable < ActiveRecord::Migration[5.2]
-  def up
-    drop_table :posts_skills
-  end
-
-  def down
-    raise ActiveRecord::IrreversibleMigration
-  end
-end

--- a/db/migrate/20200412123649_add_parent_and_volunteer_to_tasks.rb
+++ b/db/migrate/20200412123649_add_parent_and_volunteer_to_tasks.rb
@@ -1,0 +1,6 @@
+class AddParentAndVolunteerToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :parent, foreign_key: { to_table: 'users' }
+    add_reference :tasks, :volunteer, foreign_key: { to_table: 'users' }
+  end
+end

--- a/db/migrate/20200412123649_add_parent_to_tasks.rb
+++ b/db/migrate/20200412123649_add_parent_to_tasks.rb
@@ -1,5 +1,0 @@
-class AddParentToTasks < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :tasks, :parent, foreign_key: true
-  end
-end

--- a/db/migrate/20200412123710_add_volunteer_to_tasks.rb
+++ b/db/migrate/20200412123710_add_volunteer_to_tasks.rb
@@ -1,5 +1,0 @@
-class AddVolunteerToTasks < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :tasks, :volunteer, foreign_key: true
-  end
-end

--- a/db/migrate/20200412171212_update_skill_on_task_to_string.rb
+++ b/db/migrate/20200412171212_update_skill_on_task_to_string.rb
@@ -1,7 +1,6 @@
 class UpdateSkillOnTaskToString < ActiveRecord::Migration[5.2]
   def change
-    rename_column :tasks, :skill_id, :skill
-    change_column :tasks, :skill, :string
-    remove_column :tasks, :index_tasks_on_skill
+    remove_column :tasks, :skill_id, :skill
+    add_column :tasks, :skill, :string
   end
 end

--- a/db/migrate/20200413142454_update_skills.rb
+++ b/db/migrate/20200413142454_update_skills.rb
@@ -1,6 +1,0 @@
-class UpdateSkills < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :skills, :user_id
-    remove_column :skills, :index_skills_on_user_id
-  end
-end

--- a/db/migrate/20200413142746_add_volunteer_id_to_skills.rb
+++ b/db/migrate/20200413142746_add_volunteer_id_to_skills.rb
@@ -1,5 +1,0 @@
-class AddVolunteerIdToSkills < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :skills, :volunteer, foreign_key: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_13_142746) do
+ActiveRecord::Schema.define(version: 2020_04_12_224935) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
@@ -20,7 +23,7 @@ ActiveRecord::Schema.define(version: 2020_04_13_142746) do
   create_table "languages", force: :cascade do |t|
     t.integer "name"
     t.string "level"
-    t.integer "volunteer_id"
+    t.bigint "volunteer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["volunteer_id"], name: "index_languages_on_volunteer_id"
@@ -28,10 +31,10 @@ ActiveRecord::Schema.define(version: 2020_04_13_142746) do
 
   create_table "messages", force: :cascade do |t|
     t.text "content"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "task_id"
+    t.bigint "task_id"
     t.index ["task_id"], name: "index_messages_on_task_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
@@ -40,9 +43,9 @@ ActiveRecord::Schema.define(version: 2020_04_13_142746) do
     t.integer "name"
     t.string "level"
     t.integer "years_of_experience"
+    t.bigint "volunteer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "volunteer_id"
     t.index ["volunteer_id"], name: "index_skills_on_volunteer_id"
   end
 
@@ -52,11 +55,10 @@ ActiveRecord::Schema.define(version: 2020_04_13_142746) do
     t.datetime "updated_at", null: false
     t.string "task_language"
     t.integer "childs_age"
+    t.bigint "parent_id"
+    t.bigint "volunteer_id"
     t.string "skill"
-    t.integer "parent_id"
-    t.integer "volunteer_id"
     t.index ["parent_id"], name: "index_tasks_on_parent_id"
-    t.index ["skill"], name: "index_tasks_on_skill"
     t.index ["volunteer_id"], name: "index_tasks_on_volunteer_id"
   end
 
@@ -81,4 +83,10 @@ ActiveRecord::Schema.define(version: 2020_04_13_142746) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "languages", "users", column: "volunteer_id"
+  add_foreign_key "messages", "tasks"
+  add_foreign_key "messages", "users"
+  add_foreign_key "skills", "users", column: "volunteer_id"
+  add_foreign_key "tasks", "users", column: "parent_id"
+  add_foreign_key "tasks", "users", column: "volunteer_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Skill.destroy_all
+Language.destroy_all
+Message.destroy_all
+Task.destroy_all
 Volunteer.destroy_all
 Parent.destroy_all
-Message.destroy_all
 
 10.times do |i|
   volunteer = Volunteer.create!(


### PR DESCRIPTION
**Note:**
Going forwards, you'll need postgres installed and running on your machine to run the backend.
Then:
-  run `rails db:migrate:reset` to drop, recreate and migrate your local db (should just need to do this once, once you have pulled these changes)
- run `rails db:seed` to seed your local db with some test data 

**Migrations**
The migrations seemed to have got into a bit of a mess - dropping the database and recreating was failing - looked like there was a migration to drop a table but the earlier migration that added that table had been deleted, hence why I manually deleted those drop migrations.

Whilst I doing this manual edit of our existing migrations I also removed the references to `volunteer` and `parent` in the migrations and corrected the foreign key references to point at the `Users` table. I subsequently deleted any now clashing / redundant migrations too.
Note that `volunteer_id` and `parent_id` still appear in some migrations where necessary, but that is the _name_ of the columns - the actual foreign key reference is to the `Users` table. I did this for readability, and also because the `Tasks` table needs two foreign key references to the `Users` table (one for parent and one for volunteer).

**Migrating from SQLite3 to Postgres**
- I've just added the pg gem and tweaked the db config
- I also had to tweak a couple of the migrations, e.g. the ones where field types a changed to make it postgres compatible

Seems to be working fine with a local postgres db now 🎉 
