### PR TITLE
Add custom warden strategy for auth

### DIFF
--- a/app/controllers/api/v1/assign_volunteer_controller.rb
+++ b/app/controllers/api/v1/assign_volunteer_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class AssignVolunteerController < ApplicationController
-      # before_action :authenticate_user!
+      before_action :authenticate_user!
       def update
         params.require(:id)
         params.require(:volunteer)

--- a/app/controllers/api/v1/message_thread_controller.rb
+++ b/app/controllers/api/v1/message_thread_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class MessageThreadController < ApplicationController
-      # before_action :authenticate_user!
+      before_action :authenticate_user!
       def show
         task_id = params[:id]
         messages = Message.where(task_id: task_id)

--- a/app/controllers/api/v1/message_threads_for_parent_controller.rb
+++ b/app/controllers/api/v1/message_threads_for_parent_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class MessageThreadsForParentController < ApplicationController
-      # before_action :authenticate_user!
+      before_action :authenticate_user!
       def show
         user_id = params[:id]
         tasks = Task.where(parent_id: user_id)

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -1,7 +1,7 @@
 module Api
     module V1
         class MessagesController < ApplicationController
-
+            before_action :authenticate_user!
             def index
                 messages = Message.all
                 render json: messages

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -14,7 +14,8 @@ module Api
       end
 
       def destroy
-        current_user&.authentication_token = nil
+        current_user = User.find_by_email(request.headers['X-User-Email'])
+        current_user.authentication_token = nil
         if current_user&.save
           head(:ok)
         else

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -3,6 +3,7 @@
 module Api
   module V1
     class TasksController < ApplicationController
+      before_action :authenticate_user!
       def index
         tasks = Task.all
         render json: tasks

--- a/app/strategies/auth_token_strategy.rb
+++ b/app/strategies/auth_token_strategy.rb
@@ -1,0 +1,17 @@
+class AuthTokenStrategy < Warden::Strategies::Base
+  def authenticate!
+    user = User.find_by(authentication_token: auth_token)
+
+    if user
+      success!(user)
+    else
+      fail!('Invalid email or password')
+    end
+  end
+
+  private
+
+  def auth_token
+    env['HTTP_AUTHORIZATION'].to_s.remove('Bearer ')
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -283,6 +283,11 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  config.warden do |manager|
+    manager.default_strategies(scope: :user).unshift :authentication_token
+    manager.default_strategies(scope: :volunteer).unshift :authentication_token
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -285,7 +285,12 @@ Devise.setup do |config|
 
   config.warden do |manager|
     manager.default_strategies(scope: :user).unshift :authentication_token
-    manager.default_strategies(scope: :volunteer).unshift :authentication_token
+    manager.default_strategies(scope: :message_thread).unshift :authentication_token
+    manager.default_strategies(scope: :message_threads_for_parent).unshift :authentication_token
+    manager.default_strategies(scope: :assign_volunteer).unshift :authentication_token
+    manager.default_strategies(scope: :unassign_volunteer).unshift :authentication_token
+    manager.default_strategies(scope: :message).unshift :authentication_token
+    manager.default_strategies(scope: :task).unshift :authentication_token
   end
 
   # ==> Mountable engine configurations

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,1 @@
+Warden::Strategies.add(:authentication_token, AuthTokenStrategy)


### PR DESCRIPTION
Checks the request is authorised using an api token set in the `Authorization` header of the request. The auth token needs to be of the form `Bearer {authentication_token}`, where the `authentication_token` will be included in the response when the users signs up or signs in. E.g. if the `authentication_token` in the response is `1ETAFSq3iHVJUQiZbHPH` then the `Authorization` header in any api requests made for that user needs to be set as `Bearer 1ETAFSq3iHVJUQiZbHPH`

- Get `current_user` from `X-User-Email` request header when signing out, as the devise `current_user` method is returning nil and I can't work out why
- Add custom warden strategy for authentication token
- Add `before_action :authenticate_user!` to add auth to the routes that need it
